### PR TITLE
Add ranger support

### DIFF
--- a/pkg/raster/R/predict.R
+++ b/pkg/raster/R/predict.R
@@ -163,6 +163,8 @@ setMethod('predict', signature(object='Raster'),
 					}					
 				} else if (is.array(predv)) {
 					predv <- as.matrix(predv)
+				} else if (class(predv)[1] == 'ranger.prediction') {
+				  	predv <- predv$predictions
 				}
 				
 				if (isTRUE(dim(predv)[2] > 1)) {


### PR DESCRIPTION
Adds support for the [ranger](https://github.com/imbs-hl/ranger) random forest implementation.

The "mdsummer-dev" branch didn't build on my machine, but this change works in the master. 

This example (modified from your predict.R file) should work: 

```R
library(raster)

# create a RasterStack or RasterBrick with with a set of predictor layers
logo <- brick(system.file("external/rlogo.grd", package="raster"))
names(logo)

# known presence and absence points
p <- matrix(c(48, 48, 48, 53, 50, 46, 54, 70, 84, 85, 74, 84, 95, 85, 
   66, 42, 26, 4, 19, 17, 7, 14, 26, 29, 39, 45, 51, 56, 46, 38, 31, 
   22, 34, 60, 70, 73, 63, 46, 43, 28), ncol=2)

a <- matrix(c(22, 33, 64, 85, 92, 94, 59, 27, 30, 64, 60, 33, 31, 9,
   99, 67, 15, 5, 4, 30, 8, 37, 42, 27, 19, 69, 60, 73, 3, 5, 21,
   37, 52, 70, 74, 9, 13, 4, 17, 47), ncol=2)

# extract values for points
xy <- rbind(cbind(1, p), cbind(0, a))
v <- data.frame(cbind(pa=xy[,1], extract(logo, xy[,2:3])))

library(ranger)
rfmod <- ranger(pa ~., data=v)
r3 <- predict(logo, rfmod, type='response', progress='window')
```